### PR TITLE
Rename InjectReference target

### DIFF
--- a/sqlite-net-wp8.targets
+++ b/sqlite-net-wp8.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="PlatformCheck" BeforeTargets="InjectReference"
+  <Target Name="PlatformCheck" BeforeTargets="SqliteNetWP8InjectReference"
     Condition=" ( ('$(Platform)' != 'x86') AND ('$(Platform)' != 'ARM') )">
     <Error  Text="$(MSBuildThisFileName) does not work correctly on '$(Platform)' platform. You need to specify platform (x86 or ARM)." />
   </Target>
 
-  <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
+  <Target Name="SqliteNetWP8InjectReference" BeforeTargets="ResolveAssemblyReferences">
 
     <ItemGroup Condition=" '$(Platform)' == 'x86' or '$(Platform)' == 'ARM'">
       <Reference Include="Sqlite">


### PR DESCRIPTION
The InjectReference target was conflicting with one used by
Microsoft.Bcl.Compression. You couldn't have both NuGet packages in the
same project. Renamed the target to something more distinctive.
